### PR TITLE
Fix bug: Do not show date for User Not Found in visitors

### DIFF
--- a/src/app/components/visit-list/visit-list.component.html
+++ b/src/app/components/visit-list/visit-list.component.html
@@ -14,7 +14,9 @@
       {{ user?.name }}
     </h2>
     <p>
-      <ion-text> {{ exactDateAndTime(item?.$createdAt) }} </ion-text>
+      <ion-text *ngIf="user.$id !== 'deleted-user'">
+        {{ exactDateAndTime(item?.$createdAt) }}
+      </ion-text>
     </p>
   </ion-label>
 </ion-item>


### PR DESCRIPTION
When a user is not found in the visitors section, the date is still being shown. This pull request fixes the bug by adding a condition to only display the date if the user is not a 'deleted-user'. This ensures that no date is displayed for users that are not found. Fixes #523.