### PR TITLE
Fix pagination offset issue in Visitors page

### DIFF
--- a/src/app/pages/home/community/community.page.html
+++ b/src/app/pages/home/community/community.page.html
@@ -297,7 +297,10 @@
     <ion-card-content>
       <ion-list *ngIf="!(isLoadingVisits$ | async)">
         <ng-container *ngFor="let visit of (visits$ | async) | slice:0:5">
-          <app-visit-list [item]="visit"></app-visit-list>
+          <app-visit-list
+            [item]="visit"
+            *ngIf="visit?.from?.$id !== 'deleted-user'"
+          ></app-visit-list>
         </ng-container>
       </ion-list>
       <!-------------------->

--- a/src/app/pages/home/profile/settings/visitors/visitors.page.html
+++ b/src/app/pages/home/profile/settings/visitors/visitors.page.html
@@ -23,7 +23,10 @@
     <ion-card-content>
       <ion-list>
         <ng-container *ngFor="let visit of (visits$ | async)">
-          <app-visit-list [item]="visit"></app-visit-list>
+          <app-visit-list
+            [item]="visit"
+            *ngIf="visit?.from?.$id !== 'deleted-user'"
+          ></app-visit-list>
         </ng-container>
       </ion-list>
 

--- a/src/app/store/reducers/visits.reducer.ts
+++ b/src/app/store/reducers/visits.reducer.ts
@@ -36,20 +36,20 @@ const visitsReducer = createReducer(
   ),
   on(getVisitsSuccessAction, (state, action): VisitsStateInterface => {
     // Map through the documents and add deletedUser if from is null
-    // const visits = action.payload.documents.map((document) => {
-    //   if (!document.from || document.from === null) {
-    //     return {
-    //       ...document,
-    //       from: deletedUser,
-    //     };
-    //   }
-    //   return document;
-    // });
+    const visits = action.payload.documents.map((document) => {
+      if (!document.from || document.from === null) {
+        return {
+          ...document,
+          from: deletedUser,
+        };
+      }
+      return document;
+    });
 
     // Filter the documents to exclude those where from is null
-    const visits = action.payload.documents.filter(
-      (document) => document.from && document.from !== null
-    );
+    // const visits = action.payload.documents.filter(
+    //   (document) => document.from && document.from !== null
+    // );
 
     return {
       ...state,
@@ -80,20 +80,20 @@ const visitsReducer = createReducer(
     getVisitsWithOffsetSuccessAction,
     (state, action): VisitsStateInterface => {
       // Map through the documents and add deletedUser if from is null
-      // const visits = action.payload.documents.map((document) => {
-      //   if (!document.from || document.from === null) {
-      //     return {
-      //       ...document,
-      //       from: deletedUser,
-      //     };
-      //   }
-      //   return document;
-      // });
+      const visits = action.payload.documents.map((document) => {
+        if (!document.from || document.from === null) {
+          return {
+            ...document,
+            from: deletedUser,
+          };
+        }
+        return document;
+      });
 
       // Filter the documents to exclude those where from is null
-      const visits = action.payload.documents.filter(
-        (document) => document.from && document.from !== null
-      );
+      // const visits = action.payload.documents.filter(
+      //   (document) => document.from && document.from !== null
+      // );
 
       return {
         ...state,


### PR DESCRIPTION
This pull request fixes the bug in the Visitors page where the offset for pagination was not being applied correctly. The issue caused the same set of visitors to be returned instead of the next set when scrolling down. The fix ensures that the correct set of visitors is loaded and displayed when scrolling. Additionally, the visit list has been refactored to exclude deleted users. This fix improves the usability of the Visitors page, especially when there are a large number of visitors to display. Fixes #551