### PR TITLE
Exclude deleted users from leaderboard

### DIFF
--- a/src/app/services/user/user.service.ts
+++ b/src/app/services/user/user.service.ts
@@ -206,6 +206,9 @@ export class UserService {
     // Define queries
     const queries: any[] = [];
 
+    // Query for user is not deleted
+    queries.push(Query.isNotNull('userId'));
+
     // Query for users descending by last seen
     queries.push(Query.orderDesc('daystreak'));
 


### PR DESCRIPTION
This pull request updates the leaderboard logic to exclude users who have deleted their accounts. By doing so, the leaderboard will only display active users, making it more accurate and competitive. This change is part of our ongoing efforts to improve user experience and engagement. Fixes #549.