### PR TITLE
Add loading controller and error handler while deleting an account

### DIFF
--- a/src/app/models/types/states/authState.interface.ts
+++ b/src/app/models/types/states/authState.interface.ts
@@ -41,5 +41,6 @@ export interface AuthStateInterface {
   presenceError: ErrorInterface | null;
   editProfileError: ErrorInterface | null;
   accountDetailError: ErrorInterface | null;
+  isLoadingDeleteAccount: boolean;
   deleteAccountError: ErrorInterface | null;
 }

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -13,6 +13,7 @@ import { Account } from 'src/app/models/Account';
 import { User } from 'src/app/models/User';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import {
+  clearErrorsAction,
   deleteAccountAction,
   listIdentitiesAction,
   listSessionsAction,
@@ -73,7 +74,8 @@ export class AccountPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
-            // TODO: Add here error cleanup
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );
@@ -83,7 +85,8 @@ export class AccountPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
-            // TODO: Add here error cleanup
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );
@@ -97,7 +100,8 @@ export class AccountPage implements OnInit {
               'Please send your request via email to info@languageXchange.net',
               'danger'
             );
-            // TODO: Add here error cleanup
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -110,6 +110,8 @@ export class AccountPage implements OnInit {
         .subscribe((verifyEmailSuccess: boolean) => {
           if (verifyEmailSuccess) {
             this.presentToast('Email has been successfully sent.', 'success');
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -96,10 +96,7 @@ export class AccountPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
-            this.presentToast(
-              'Please send your request via email to info@languageXchange.net',
-              'danger'
-            );
+            this.presentErrorAlertAfterDelete();
             // Error Cleanup
             this.store.dispatch(clearErrorsAction());
           }
@@ -196,6 +193,17 @@ export class AccountPage implements OnInit {
           },
         },
       ],
+    });
+
+    await alert.present();
+  }
+
+  async presentErrorAlertAfterDelete() {
+    const alert = await this.alertController.create({
+      header: 'Information',
+      message:
+        'Please send your deletion request via email to info@languageXchange.net',
+      buttons: ['OK'],
     });
 
     await alert.present();

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -27,6 +27,8 @@ import {
   accountDetailErrorSelector,
   verifyEmailErrorSelector,
   verifyEmailSuccessSelector,
+  isLoadingDeleteAccountSelector,
+  deleteAccountErrorSelector,
 } from 'src/app/store/selectors/auth.selector';
 
 @Component({
@@ -45,6 +47,7 @@ export class AccountPage implements OnInit {
   sessions$: Observable<Models.Session[]> = null;
   isLoading$: Observable<boolean> = null;
   verifyEmailSuccess$: Observable<boolean> = null;
+  isLoadingDeleteAccount$: Observable<boolean> = null;
 
   verifyButtonDisabled = false; // to control the button's state
   verifyButtonText = 'Verify'; // to hold the button's text
@@ -82,6 +85,19 @@ export class AccountPage implements OnInit {
           }
         })
     );
+    this.subscription.add(
+      this.store
+        .pipe(select(deleteAccountErrorSelector))
+        .subscribe((error: ErrorInterface) => {
+          if (error) {
+            this.presentToast(error.message, 'danger');
+            this.presentToast(
+              'Please send your request via email to info@languageXchange.net',
+              'danger'
+            );
+          }
+        })
+    );
 
     // Present Toast if verifyEmailSuccess
     this.subscription.add(
@@ -111,6 +127,9 @@ export class AccountPage implements OnInit {
     this.identities$ = this.store.pipe(select(identitiesSelector));
     this.sessions$ = this.store.pipe(select(sessionsSelector));
     this.isLoading$ = this.store.pipe(select(isLoadingSelector));
+    this.isLoadingDeleteAccount$ = this.store.pipe(
+      select(isLoadingDeleteAccountSelector)
+    );
   }
 
   verifyEmail() {

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -115,6 +115,17 @@ export class AccountPage implements OnInit {
           }
         })
     );
+
+    // isLoadingDeleteAccount
+    this.subscription.add(
+      this.store
+        .pipe(select(isLoadingDeleteAccountSelector))
+        .subscribe((isLoadingDeleteAccount: boolean) => {
+          if (isLoadingDeleteAccount) {
+            this.presentToast('Deleting account, please wait', 'warning');
+          }
+        })
+    );
   }
 
   ionViewWillLeave() {
@@ -133,9 +144,6 @@ export class AccountPage implements OnInit {
     this.identities$ = this.store.pipe(select(identitiesSelector));
     this.sessions$ = this.store.pipe(select(sessionsSelector));
     this.isLoading$ = this.store.pipe(select(isLoadingSelector));
-    this.isLoadingDeleteAccount$ = this.store.pipe(
-      select(isLoadingDeleteAccountSelector)
-    );
   }
 
   verifyEmail() {

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -73,6 +73,7 @@ export class AccountPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
+            // TODO: Add here error cleanup
           }
         })
     );
@@ -82,6 +83,7 @@ export class AccountPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
+            // TODO: Add here error cleanup
           }
         })
     );
@@ -95,6 +97,7 @@ export class AccountPage implements OnInit {
               'Please send your request via email to info@languageXchange.net',
               'danger'
             );
+            // TODO: Add here error cleanup
           }
         })
     );

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -143,7 +143,7 @@ export class AccountPage implements OnInit {
     this.currentUser$ = this.store.pipe(select(currentUserSelector));
     this.identities$ = this.store.pipe(select(identitiesSelector));
     this.sessions$ = this.store.pipe(select(sessionsSelector));
-    this.isLoading$ = this.store.pipe(select(isLoadingSelector));
+    this.isLoading$ = this.store.pipe(select(isLoadingSelector)); // TODO: Unused yet
   }
 
   verifyEmail() {

--- a/src/app/pages/login/reset-password/reset-password.page.ts
+++ b/src/app/pages/login/reset-password/reset-password.page.ts
@@ -5,7 +5,10 @@ import { Store, select } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 
-import { resetPasswordAction } from 'src/app/store/actions/auth.action';
+import {
+  clearErrorsAction,
+  resetPasswordAction,
+} from 'src/app/store/actions/auth.action';
 import {
   isLoadingSelector,
   resetPasswordErrorSelector,
@@ -40,6 +43,8 @@ export class ResetPasswordPage implements OnInit {
         .subscribe((error: ErrorInterface) => {
           if (error) {
             this.presentToast(error.message, 'danger');
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );
@@ -52,6 +57,8 @@ export class ResetPasswordPage implements OnInit {
           this.form.reset();
           if (response) {
             this.presentToast('Email has been successfully sent.', 'success');
+            // Error Cleanup
+            this.store.dispatch(clearErrorsAction());
           }
         })
     );

--- a/src/app/store/reducers/auth.reducer.ts
+++ b/src/app/store/reducers/auth.reducer.ts
@@ -142,6 +142,7 @@ const initialState: AuthStateInterface = {
   profileError: null,
   editProfileError: null,
   accountDetailError: null,
+  isLoadingDeleteAccount: false,
   deleteAccountError: null,
 };
 
@@ -757,7 +758,7 @@ const authReducer = createReducer(
     deleteAccountAction,
     (state): AuthStateInterface => ({
       ...state,
-      isLoading: true,
+      isLoadingDeleteAccount: true,
     })
   ),
   on(
@@ -770,7 +771,7 @@ const authReducer = createReducer(
     deleteAccountFailureAction,
     (state, action): AuthStateInterface => ({
       ...state,
-      isLoading: false,
+      isLoadingDeleteAccount: false,
       deleteAccountError: action.error,
     })
   ),

--- a/src/app/store/reducers/auth.reducer.ts
+++ b/src/app/store/reducers/auth.reducer.ts
@@ -981,6 +981,8 @@ const authReducer = createReducer(
       editProfileError: null,
       accountDetailError: null,
       deleteAccountError: null,
+      verifyEmailSuccess: false,
+      resetPasswordSuccess: false,
     })
   )
 );

--- a/src/app/store/selectors/auth.selector.ts
+++ b/src/app/store/selectors/auth.selector.ts
@@ -179,3 +179,13 @@ export const unArchiveRoomErrorSelector = createSelector(
   authFeatureSelector,
   (authState: AuthStateInterface) => authState.unArchiveRoomError
 );
+
+export const isLoadingDeleteAccountSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.isLoadingDeleteAccount
+);
+
+export const deleteAccountErrorSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.deleteAccountError
+);


### PR DESCRIPTION
**Description:**

This pull request adds a loading controller that displays a loading spinner or progress bar while the account deletion process is ongoing. This provides immediate feedback to the user and reassures them that their request is being processed. Additionally, it fixes a bug where an error message persists and is shown every time the "Community" button is pressed after pressing the "User not found" button in the "Profile Visitors" section.

Fixes #556, #519