### PR TITLE
Fix filter bug for multiple languages

### DIFF
--- a/src/app/services/user/user.service.ts
+++ b/src/app/services/user/user.service.ts
@@ -54,7 +54,7 @@ export class UserService {
 
     // Query for users with the selected languages filter
     if (currentUser?.languageArray.length > 0) {
-      const keywords = currentUser.languageArray.join(' ');
+      const keywords = currentUser.languageArray;
       // OR Query for users with any of the selected languages
       queries.push(Query.contains('languageArray', keywords));
     }
@@ -402,7 +402,7 @@ export class UserService {
 
     // Query for users with the selected languages filter
     if (filterData?.languages.length > 0) {
-      const keywords = filterData.languages.join(' ');
+      const keywords = filterData.languages;
       // OR Query for users with any of the selected languages
       queries.push(Query.contains('languageArray', keywords));
     }


### PR DESCRIPTION
This pull request fixes a bug where the application does not show any results when filtering with 2 or more languages. The bug is caused by joining the selected languages with a space character, which is incorrect. This pull request updates the code to correctly handle multiple languages by passing the array of selected languages directly to the query. Fixes #561.