### PR TITLE
Fix issue with keyboard closing when clicking "Send Message" button

### DIFF
--- a/src/app/pages/home/messages/chat/chat.page.html
+++ b/src/app/pages/home/messages/chat/chat.page.html
@@ -57,12 +57,15 @@
           <app-pre-chat-box [tempMsg]="tempMsg"></app-pre-chat-box>
         </ion-item-group>
       </div>
-      <app-pre-chat-box *ngIf="isLoadingImage" [tempMsg]="isLoadingImageMsg"></app-pre-chat-box>
+      <app-pre-chat-box
+        *ngIf="isLoadingImage"
+        [tempMsg]="isLoadingImageMsg"
+      ></app-pre-chat-box>
     </div>
   </ion-list>
 </ion-content>
 
-<ion-footer>
+<ion-footer (click)="footerClicked($event)">
   <ion-toolbar>
     <form [formGroup]="form" (ngSubmit)="submitForm()">
       <ion-item *ngIf="replyMessage?.$id">

--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -861,7 +861,12 @@ export class ChatPage implements OnInit, OnDestroy {
   }
 
   onTypingStatusChange() {
-    // console.log('onTypingStatusChange', this.isTyping);
+    console.log('onTypingStatusChange', this.isTyping);
+  }
+
+  footerClicked(event: Event) {
+    // If the footer is clicked, set the focus back to the textarea
+    this.myTextArea.setFocus();
   }
 
   redirectUserProfile() {


### PR DESCRIPTION
This pull request fixes the bug where the keyboard unexpectedly closes when clicking the "Send Message" button in the chat interface. The fix ensures that the keyboard remains open after clicking the button, allowing users to continue typing without needing to click on the text input field again.

Fixes #563